### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+cache
+.git
+.gitignore
+.DS_Store
+npm-debug.log
+pnpm-debug.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Shared base image for all stages. We keep Node 22 to match the project setup.
+FROM node:22-bookworm-slim AS base
+
+WORKDIR /app
+
+# Enable pnpm via Corepack so we can use the repo's existing pnpm lockfile.
+RUN corepack enable
+
+# Install all dependencies once so the build stage has everything it needs.
+FROM base AS deps
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Build the TypeScript app and copy static assets into dist/.
+FROM deps AS build
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY viewer ./viewer
+COPY data ./data
+RUN pnpm build
+
+# Create a production-only node_modules tree for the final runtime image.
+FROM base AS prod-deps
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
+
+# Final image: only the compiled app, bundled demo data, and runtime dependencies.
+FROM node:22-bookworm-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3334
+
+# The app serves viewer assets and file icons from node_modules at runtime, so we copy them in.
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/viewer ./viewer
+COPY --from=build /app/data ./data
+COPY package.json ./
+
+EXPOSE 3334
+
+# Start the compiled server.
+CMD ["node", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  demo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${PORT:-3334}:3334"
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${PORT:-3334}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "typescript": "^6.0.2"
   },
   "scripts": {
+    "start": "ts-node ./src/server.ts",
+    "start:prod": "node ./dist/server.js",
     "watch": "node --watch -r ts-node/register ./src/server.ts",
     "build": "rimraf dist/ && tsc && copyfiles -u 1 \"src/**/*.html\" \"src/**/*.ico\" dist/"
   },

--- a/readme.md
+++ b/readme.md
@@ -14,21 +14,38 @@ https://iiif.sozialarchiv.ch/?manifest=https://iiif.sozialarchiv.ch/iiif/collect
 1. Clone or download repository
 2. Install dependencies
   ```sh
-  // with npm
+  # with pnpm
+  pnpm install
+
+  # with npm
   npm install
-  
-  // with yarn
-  yarn install
   ```
 3. Copy env.example to .env and set port.
-2. Start server
+4. Start server
   ```sh
-  // with npm
-  npm run watch-server
-  
-  // with yarn
-  yarn run watch-server
+  # with pnpm
+  pnpm watch
+
+  # with npm
+  npm run watch
   ```
+
+## Docker
+
+This project can also run in Docker.
+
+1. Copy `env.example` to `.env` if you want to customize the port
+2. Build and start the container:
+   ```bash
+   docker compose up --build
+   ```
+3. Open `http://localhost:3334`
+
+To stop the container:
+
+```bash
+docker compose down
+```
 
 ## License
 


### PR DESCRIPTION
## Summary
Add Docker support for running the Archival IIIF demo in a container.

## What changed
- add a multi-stage Dockerfile for building and running the app
- add docker-compose.yml for local container startup
- add .dockerignore to keep Docker builds lean
- add start and start:prod scripts in package.json
- update the README and fix the stale startup command

## Notes
The container keeps runtime node_modules because the app serves viewer assets and file icons directly from installed packages.